### PR TITLE
update FuseVfsStat.cs to match kernel implementation.

### DIFF
--- a/FuseDotNet/Fuse.cs
+++ b/FuseDotNet/Fuse.cs
@@ -56,7 +56,8 @@ public static class Fuse
             return status;
         }
         
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) == true) {
+        #if NET6_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) == true && RuntimeInformation.OSArchitecture == Architecture.X64) {
             
             var status = NativeMethods.BSDFuseMainReal(utf8args.Length, utf8args, null, 0, 0);
 
@@ -64,6 +65,7 @@ public static class Fuse
 
             return status;
         }
+        #endif
 
         return PosixResult.ENOTSUP;
     }
@@ -76,7 +78,7 @@ public static class Fuse
     /// <param name="args">Command line arguments to pass to fuse_main().</param>
     /// <param name="logger"><see cref="ILogger"/> that will log all FuseDotNet debug information.</param>
     /// <exception cref="PosixException">If the mount fails.</exception>
-    public static unsafe void Mount(this IFuseOperations operations, IEnumerable<string> args, ILogger? logger = null)
+    public static void Mount(this IFuseOperations operations, IEnumerable<string> args, ILogger? logger = null)
     {
         logger ??= new NullLogger();
 
@@ -141,7 +143,8 @@ public static class Fuse
             }
         }
         
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) == true)
+        #if NET6_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) == true && RuntimeInformation.OSArchitecture == Architecture.X64)
         {
             var fuseOperationProxy = new BSDFuseOperationProxy(operations, logger);
             var fuseOperations = new BSDFuseOperations
@@ -201,5 +204,6 @@ public static class Fuse
                 throw new PosixException(status);
             }
         }
+        #endif
     }
 }

--- a/FuseDotNet/FuseDotNet.csproj
+++ b/FuseDotNet/FuseDotNet.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\FuseDotNet.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard20;netstandard21;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FuseDotNet/FuseDotNet.csproj
+++ b/FuseDotNet/FuseDotNet.csproj
@@ -6,6 +6,7 @@
     <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\FuseDotNet.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FuseDotNet/FuseOperationProxy.cs
+++ b/FuseDotNet/FuseOperationProxy.cs
@@ -2,6 +2,7 @@ using FuseDotNet.Extensions;
 using FuseDotNet.Logging;
 using System;
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Text;
 
 #pragma warning disable IDE0079 // Remove unnecessary suppression
@@ -22,7 +23,7 @@ namespace FuseDotNet;
 /// <param name="logger">
 /// A <see cref="ILogger"/> that handle all logging.
 /// </param>
-internal sealed class FuseOperationProxy(IFuseOperations operations, ILogger logger)
+internal sealed class LinuxFuseOperationProxy(IFuseOperations operations, ILogger logger)
 {
     private readonly IFuseOperations operations = operations;
 
@@ -340,11 +341,466 @@ internal sealed class FuseOperationProxy(IFuseOperations operations, ILogger log
         }
     }
 
-    internal int statfs(nint path, ref FuseVfsStat statvfs)
+    internal int statfs(nint path, ref LinuxVfsStat statvfs)
     {
         try
         {
-            var result = operations.StatFs(FuseHelper.SpanFromIntPtr(path), out statvfs);
+            var result = operations.StatFs(FuseHelper.SpanFromIntPtr(path), out FuseVfsStat stats);
+            LinuxVfsStat nativeStats = new LinuxVfsStat();
+            stats.ToLinuxVfsStat(ref nativeStats);
+            statvfs = nativeStats;
+            
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"statfs(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int getattr(nint path, nint statptr, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.GetAttr(FuseHelper.SpanFromIntPtr(path), out var stat, ref fileInfo);
+            stat.MarshalToNative(statptr);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"getattr(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal unsafe int readdir(nint path, nint buf, nint fuse_fill_dir_t, long offset, ref FuseFileInfo fileInfo, FuseReadDirFlags flags)
+    {
+        try
+        {
+            var pathPtr = FuseHelper.SpanFromIntPtr(path);
+
+            var result = operations.ReadDir(pathPtr, out var entries, ref fileInfo, offset, flags);
+
+            if (result != PosixResult.Success)
+            {
+                return -(int)result;
+            }
+
+            var fuse_fill_dir = (delegate* unmanaged[Cdecl]<nint, in byte, void*, long, FuseFillDirFlags, int>)fuse_fill_dir_t;
+
+            if (logger.DebugEnabled)
+            {
+                var pathstr = FuseHelper.GetString(pathPtr);
+
+                logger.Debug($"Filling files for directory '{pathstr}'");
+            }
+
+            var stat = stackalloc byte[FuseFileStat.NativeStructSize];
+
+            var name = ArrayPool<byte>.Shared.Rent(512);
+
+            try
+            {
+                foreach (var file in entries)
+                {
+                    if (logger.DebugEnabled)
+                    {
+                        logger.Debug($"Directory entry: {file}");
+                    }
+
+                    file.Stat.MarshalToNative(stat);
+
+                    var length = Encoding.UTF8.GetByteCount(file.Name) + 1;  // Extra byte for null terminator
+
+                    if (name.Length < length)
+                    {
+                        ArrayPool<byte>.Shared.Return(name);
+                        name = null;
+                        name = ArrayPool<byte>.Shared.Rent(length);
+                    }
+
+                    length = Encoding.UTF8.GetBytes(file.Name, 0, file.Name.Length, name, 0);
+                    
+                    name[length] = 0; // Add null terminator
+
+                    var fill_result = fuse_fill_dir(buf, name[0], stat, file.Offset, file.Flags);
+
+                    if (fill_result != 0)
+                    {
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                if (name is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(name);
+                }
+            }
+
+            if (logger.DebugEnabled)
+            {
+                logger.Debug($"Finished filling files for directory");
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"readdir(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int read(nint path, nint buffer, nint size, long position, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.Read(FuseHelper.SpanFromIntPtr(path), new(buffer, (int)size), position, out var readLength, ref fileInfo);
+            if (result == PosixResult.Success)
+            {
+                return readLength;
+            }
+
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"read(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+}
+
+internal sealed class BSDFuseOperationProxy(IFuseOperations operations, ILogger logger)
+{
+    private readonly IFuseOperations operations = operations;
+
+    private readonly ILogger logger = logger;
+
+    internal int readlink(nint path, nint target, nint size)
+    {
+        try
+        {
+            var result = operations.ReadLink(FuseHelper.SpanFromIntPtr(path), new(target, (int)size));
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"readlink(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int link(nint path, nint target)
+    {
+        try
+        {
+            var result = operations.Link(from: FuseHelper.SpanFromIntPtr(path), to: FuseHelper.SpanFromIntPtr(path));
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"link(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int mkdir(nint path, PosixFileMode mode)
+    {
+        try
+        {
+            var result = operations.MkDir(FuseHelper.SpanFromIntPtr(path), mode);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"mkdir(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int flush(nint path, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.Flush(FuseHelper.SpanFromIntPtr(path), ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"flush(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int write(nint path, nint buffer, nint size, long position, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.Write(FuseHelper.SpanFromIntPtr(path), new(buffer, (int)size), position, out var writtenLength, ref fileInfo);
+            if (result == PosixResult.Success)
+            {
+                return writtenLength;
+            }
+
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"write(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int unlink(nint path)
+    {
+        try
+        {
+            var result = operations.Unlink(FuseHelper.SpanFromIntPtr(path));
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"unlink(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int ioctl(nint path, int cmd, nint arg, ref FuseFileInfo fileInfo, FuseIoctlFlags flags, nint data)
+    {
+        try
+        {
+            var result = operations.IoCtl(FuseHelper.SpanFromIntPtr(path), cmd, arg, ref fileInfo, flags, data);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"open(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal unsafe int utimens(nint path, nint timespec, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var ts = (TimeSpec*)timespec;
+            var result = operations.UTime(FuseHelper.SpanFromIntPtr(path), atime: ts[0], mtime: ts[1], ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"utimens(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int create(nint path, PosixFileMode mode, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.Create(FuseHelper.SpanFromIntPtr(path), mode, ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"create(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int symlink(nint path, nint target)
+    {
+        try
+        {
+            var result = operations.SymLink(FuseHelper.SpanFromIntPtr(path), FuseHelper.SpanFromIntPtr(target));
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"symlink(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int rename(nint path, nint target)
+    {
+        try
+        {
+            var result = operations.Rename(FuseHelper.SpanFromIntPtr(path), FuseHelper.SpanFromIntPtr(target));
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"rename(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int rmdir(nint path)
+    {
+        try
+        {
+            var result = operations.RmDir(FuseHelper.SpanFromIntPtr(path));
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"rmdir(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int truncate(nint path, long size)
+    {
+        try
+        {
+            var result = operations.Truncate(FuseHelper.SpanFromIntPtr(path), size);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"truncate(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int open(nint path, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.Open(FuseHelper.SpanFromIntPtr(path), ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"open(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int opendir(nint path, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.OpenDir(FuseHelper.SpanFromIntPtr(path), ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"opendir(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int fsync(nint path, int datasync, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.FSync(FuseHelper.SpanFromIntPtr(path), datasync != 0, ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"fsync(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int release(nint path, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.Release(FuseHelper.SpanFromIntPtr(path), ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"release(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int releasedir(nint path, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.ReleaseDir(FuseHelper.SpanFromIntPtr(path), ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"releasedir(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal nint init(ref FuseConnInfo fuse_conn_info)
+    {
+        try
+        {
+            operations.Init(ref fuse_conn_info);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"init(): {ex}");
+            return 0;
+        }
+    }
+
+    internal int access(nint path, PosixAccessMode mask)
+    {
+        try
+        {
+            var result = operations.Access(FuseHelper.SpanFromIntPtr(path), mask);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"access(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal void destroy(nint context)
+    {
+        try
+        {
+            operations.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"destroy(): {ex}");
+        }
+    }
+
+    internal int fsyncdir(nint path, int datasync, ref FuseFileInfo fileInfo)
+    {
+        try
+        {
+            var result = operations.FSyncDir(FuseHelper.SpanFromIntPtr(path), datasync != 0, ref fileInfo);
+            return -(int)result;
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"fsyncdir(): {ex}");
+            return -(int)ex.ToPosixResult();
+        }
+    }
+
+    internal int statfs(nint path, ref BSDVfsStat statvfs)
+    {
+        try
+        {
+            var result = operations.StatFs(FuseHelper.SpanFromIntPtr(path), out FuseVfsStat stats);
+            BSDVfsStat nativeStats = new BSDVfsStat();
+            stats.ToBSDVfsStat(ref nativeStats);
+            statvfs = nativeStats;
+            
             return -(int)result;
         }
         catch (Exception ex)

--- a/FuseDotNet/FuseVfsStat.cs
+++ b/FuseDotNet/FuseVfsStat.cs
@@ -8,19 +8,122 @@
  * the letter of the standard, this entire interface is completely
  * unspecified!)
  */
+
+public struct BSDVfsStat
+{
+    public long f_bavail;       /* Number of blocks */
+    public long f_bfree;
+    public long f_blocks;
+    public long f_favail;       /* Number of files (e.g., inodes) */
+    public long f_ffree;
+    public long f_files;
+    public uint f_bsize;        /* Size of blocks counted above */
+    public uint f_flag;
+    public uint f_frsize;  /* Size of fragments */
+    public uint f_fsid;    /* Not meaningful */
+    public uint f_namemax; /* Same as pathconf(_PC_NAME_MAX) */
+    
+    public FuseVfsStat ToFuseVfsStat()
+    {
+        FuseVfsStat stats = new FuseVfsStat
+        {
+            f_bsize   = f_bsize,
+            f_frsize  = f_frsize,
+            f_blocks  = (ulong)f_blocks,
+            f_bfree   = (ulong)f_bfree,
+            f_bavail  = (ulong)f_bavail,
+            f_files   = (ulong)f_files,
+            f_ffree   = (ulong)f_ffree,
+            f_favail  = (ulong)f_favail,
+            f_fsid    = f_fsid,
+            f_flag    = f_flag,
+            f_namemax = f_namemax
+        };
+
+        return stats;
+    }
+}
+
+public struct LinuxVfsStat
+{
+    public ulong f_bsize;   /* Size of data blocks on the filesystem. */
+    public ulong f_frsize;  /* Preferred size of data fragments on the filesystem. This does not necessarily need to match f_bsize. */
+    public ulong f_blocks;  /* Total count of data blocks on the filesystem. */
+    public ulong f_bfree;   /* Free data blocks on the filesystem for all users. */
+    public ulong f_bavail;  /* Free data blocks on the filesystem for non-privledged users. */
+    
+    public ulong f_files;  /* Total count of inodes on the filesystem. */
+    public ulong f_ffree;  /* Free inodes on the filesystem for all users. */
+    public ulong f_favail; /* Free inodes on the filesystem for non-privledged users. */
+    
+    public ulong f_fsid;    /* Filesystem ID. Optional, but useful for identification. */
+    public ulong f_flag;    /* Mounting flags. */
+    public ulong f_namemax; /* Max length in bytes of inode names. */
+
+    public FuseVfsStat ToFuseVfsStat()
+    {
+        FuseVfsStat stats = new FuseVfsStat
+        {
+            f_bsize   = f_bsize,
+            f_frsize  = f_frsize,
+            f_blocks  = f_blocks,
+            f_bfree   = f_bfree,
+            f_bavail  = f_bavail,
+            f_files   = f_files,
+            f_ffree   = f_ffree,
+            f_favail  = f_favail,
+            f_fsid    = f_fsid,
+            f_flag    = f_flag,
+            f_namemax = f_namemax
+        };
+
+        return stats;
+    }
+}
+
 public struct FuseVfsStat
 {
-    public ulong f_bsize;  /* Size of blocks counted above */
-    public ulong f_frsize; /* Size of fragments */
-    public ulong f_blocks;
-    public ulong f_bfree;
-    public ulong f_bavail;  /* Number of blocks */
+    public ulong f_bsize;   /* Size of data blocks on the filesystem. */
+    public ulong f_frsize;  /* Preferred size of data fragments on the filesystem. This does not necessarily need to match f_bsize. */
+    public ulong f_blocks;  /* Total count of data blocks on the filesystem. */
+    public ulong f_bfree;   /* Free data blocks on the filesystem for all users. */
+    public ulong f_bavail;  /* Free data blocks on the filesystem for non-privledged users. */
     
-    public ulong f_files;
-    public ulong f_ffree;
-    public ulong f_favail;  /* Number of files (e.g., inodes) */
+    public ulong f_files;   /* Total count of inodes on the filesystem. */
+    public ulong f_ffree;   /* Free inodes on the filesystem for all users. */
+    public ulong f_favail;  /* Free inodes on the filesystem for non-privledged users. */
     
-    public ulong f_fsid;    /* Not meaningful */
-    public ulong f_flag;
-    public ulong f_namemax; /* Same as pathconf(_PC_NAME_MAX) */
+    public ulong f_fsid;    /* Filesystem ID. Optional, but useful for identification. */
+    public ulong f_flag;    /* Mounting flags. */
+    public ulong f_namemax; /* Max length in bytes of inode names. */
+    
+    public void ToLinuxVfsStat(ref LinuxVfsStat stats)
+    {
+        stats.f_bsize   = f_bsize;
+        stats.f_frsize  = f_frsize;
+        stats.f_blocks  = f_blocks;
+        stats.f_bfree   = f_bfree;
+        stats.f_bavail  = f_bavail;
+        stats.f_files   = f_files;
+        stats.f_ffree   = f_ffree;
+        stats.f_favail  = f_favail;
+        stats.f_fsid    = f_fsid;
+        stats.f_flag    = f_flag; 
+        stats.f_namemax = f_namemax;
+    }
+    
+    public void ToBSDVfsStat(ref BSDVfsStat stats)
+    {
+        stats.f_bsize   = (uint)f_bsize;
+        stats.f_frsize  = (uint)f_frsize;
+        stats.f_blocks  = (long)f_blocks;
+        stats.f_bfree   = (long)f_bfree;
+        stats.f_bavail  = (long)f_bavail;
+        stats.f_files   = (long)f_files;
+        stats.f_ffree   = (long)f_ffree;
+        stats.f_favail  = (long)f_favail;
+        stats.f_fsid    = (uint)f_fsid;
+        stats.f_flag    = (uint)f_flag;
+        stats.f_namemax = (uint)f_namemax;
+    }
 }

--- a/FuseDotNet/FuseVfsStat.cs
+++ b/FuseDotNet/FuseVfsStat.cs
@@ -10,15 +10,17 @@
  */
 public struct FuseVfsStat
 {
-    public long f_bavail;       /* Number of blocks */
-    public long f_bfree;
-    public long f_blocks;
-    public long f_favail;       /* Number of files (e.g., inodes) */
-    public long f_ffree;
-    public long f_files;
-    public uint f_bsize;        /* Size of blocks counted above */
-    public uint f_flag;
-    public uint f_frsize;       /* Size of fragments */
-    public uint f_fsid;         /* Not meaningful */
-    public uint f_namemax;      /* Same as pathconf(_PC_NAME_MAX) */
+    public ulong f_bsize;  /* Size of blocks counted above */
+    public ulong f_frsize; /* Size of fragments */
+    public ulong f_blocks;
+    public ulong f_bfree;
+    public ulong f_bavail;  /* Number of blocks */
+    
+    public ulong f_files;
+    public ulong f_ffree;
+    public ulong f_favail;  /* Number of files (e.g., inodes) */
+    
+    public ulong f_fsid;    /* Not meaningful */
+    public ulong f_flag;
+    public ulong f_namemax; /* Same as pathconf(_PC_NAME_MAX) */
 }

--- a/FuseDotNet/Native/FuseOperations.cs
+++ b/FuseDotNet/Native/FuseOperations.cs
@@ -18,7 +18,7 @@ namespace FuseDotNet.Native;
 /// </summary>
 /// <remarks>This is the same struct as <c>FUSE_OPERATIONS</c> (fuse.h) in the C version of Fuse.</remarks>
 [StructLayout(LayoutKind.Sequential, Pack = 4)]
-internal sealed class FuseOperations
+internal sealed class LinuxFuseOperations
 {
     #region Delegates
 
@@ -39,7 +39,101 @@ internal sealed class FuseOperations
 	public delegate int fuse_f_open(nint path, ref FuseFileInfo fileInfo);
 	public delegate int fuse_f_read(nint path, nint buffer, nint size, long position, ref FuseFileInfo fileInfo);
 	public delegate int fuse_f_write(nint path, nint buffer, nint size, long position, ref FuseFileInfo fileInfo);
-	public delegate int fuse_f_statfs(nint path, ref FuseVfsStat statvfs);
+	public delegate int fuse_f_statfs(nint path, ref LinuxVfsStat statvfs);
+	public delegate int fuse_f_flush(nint path, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_release(nint path, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_fsync(nint path, int datasync, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_setxattr(nint path, nint name, nint value, nint size, int flags);
+	public delegate int fuse_f_getxattr(nint path, nint name, nint value, nint size);
+	public delegate int fuse_f_listxattr(nint path, nint list, nint size);
+	public delegate int fuse_f_removexattr(nint path, nint target);
+	public delegate int fuse_f_opendir(nint path, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_readdir(nint path, nint buf, nint fuse_fill_dir_t, long offset, ref FuseFileInfo fileInfo, FuseReadDirFlags flags);
+	public delegate int fuse_f_releasedir(nint path, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_fsyncdir(nint path, int datasync, ref FuseFileInfo fileInfo);
+	public delegate nint fuse_f_init(ref FuseConnInfo fuse_conn_info);
+	public delegate void fuse_f_destroy(nint context);
+	public delegate int fuse_f_access(nint path, PosixAccessMode mask);
+	public delegate int fuse_f_create(nint path, PosixFileMode mode, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_lock(nint path, ref FuseFileInfo fileInfo, int cmd, nint flock);
+	public delegate int fuse_f_utimens(nint path, nint timespec, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_bmap(nint path, nint blocksize, out ulong idx);
+	public delegate int fuse_f_ioctl(nint path, int cmd, nint arg, ref FuseFileInfo fileInfo, FuseIoctlFlags flags, nint data);
+	public delegate int fuse_f_poll(nint path, ref FuseFileInfo fileInfo, nint fuse_pollhandle, ref uint reventsp);
+	public delegate int fuse_f_write_buf(nint path, nint fuse_bufvec, long off, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_read_buf(nint path, nint ppbuf, nint size, long off, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_flock(nint path, ref FuseFileInfo fileInfo, int op);
+	public delegate int fuse_f_fallocate(nint path, PosixFileMode mode, long offset, long length, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_copy_file_range(nint path_in, ref FuseFileInfo fi_in, long offset_in, nint path_out, ref FuseFileInfo fi_out, long offset_out, nint size, int flags);
+	public delegate int fuse_f_lseek(nint path, long offset, int whence, ref FuseFileInfo fileInfo);
+	#endregion Delegates
+
+	public fuse_f_getattr? getattr;
+	public fuse_f_readlink? readlink;
+	public fuse_f_mknod? mknod;
+	public fuse_f_mkdir? mkdir;
+	public fuse_f_unlink? unlink;
+	public fuse_f_rmdir? rmdir;
+	public fuse_f_symlink? symlink;
+	public fuse_f_rename? rename;
+	public fuse_f_link? link;
+	public fuse_f_chmod? chmod;
+	public fuse_f_chown? chown;
+	public fuse_f_truncate? truncate;
+	public fuse_f_open? open;
+	public fuse_f_read? read;
+	public fuse_f_write? write;
+	public fuse_f_statfs? statfs;
+	public fuse_f_flush? flush;
+	public fuse_f_release? release;
+	public fuse_f_fsync? fsync;
+	public fuse_f_setxattr? setxattr;
+	public fuse_f_getxattr? getxattr;
+	public fuse_f_listxattr? listxattr;
+	public fuse_f_removexattr? removexattr;
+	public fuse_f_opendir? opendir;
+	public fuse_f_readdir? readdir;
+	public fuse_f_releasedir? releasedir;
+	public fuse_f_fsyncdir? fsyncdir;
+	public fuse_f_init? init;
+	public fuse_f_destroy? destroy;
+	public fuse_f_access? access;
+	public fuse_f_create? create;
+	public fuse_f_lock? @lock;
+	public fuse_f_utimens? utimens;
+	public fuse_f_bmap? bmap;
+	public fuse_f_ioctl? ioctl;
+	public fuse_f_poll? poll;
+	public fuse_f_write_buf? write_buf;
+	public fuse_f_read_buf? read_buf;
+	public fuse_f_flock? flock;
+	public fuse_f_fallocate? fallocate;
+	public fuse_f_copy_file_range? copy_file_range;
+	public fuse_f_lseek? lseek;
+}
+
+internal sealed class BSDFuseOperations
+{
+    #region Delegates
+
+    public delegate int fuse_f_fill_dir(nint buf, [MarshalAs(NativeMethods.UnmanagedStringType)] string name, nint stat, long off, FuseFillDirFlags flags);
+
+    public delegate int fuse_f_getattr(nint path, nint stat, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_readlink(nint path, nint target, nint size);
+	public delegate int fuse_f_mknod(nint path, PosixFileMode mode, int dev);
+	public delegate int fuse_f_mkdir(nint path, PosixFileMode mode);
+	public delegate int fuse_f_unlink(nint path);
+	public delegate int fuse_f_rmdir(nint path);
+	public delegate int fuse_f_symlink(nint path, nint target);
+	public delegate int fuse_f_rename(nint path, nint target);
+	public delegate int fuse_f_link(nint path, nint target);
+	public delegate int fuse_f_chmod(nint path, PosixFileMode mode);
+	public delegate int fuse_f_chown(nint path, int uid, int gid);
+	public delegate int fuse_f_truncate(nint path, long size);
+	public delegate int fuse_f_open(nint path, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_read(nint path, nint buffer, nint size, long position, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_write(nint path, nint buffer, nint size, long position, ref FuseFileInfo fileInfo);
+	public delegate int fuse_f_statfs(nint path, ref BSDVfsStat statvfs);
 	public delegate int fuse_f_flush(nint path, ref FuseFileInfo fileInfo);
 	public delegate int fuse_f_release(nint path, ref FuseFileInfo fileInfo);
 	public delegate int fuse_f_fsync(nint path, int datasync, ref FuseFileInfo fileInfo);

--- a/FuseDotNet/Native/FuseOperations.cs
+++ b/FuseDotNet/Native/FuseOperations.cs
@@ -112,6 +112,7 @@ internal sealed class LinuxFuseOperations
 	public fuse_f_lseek? lseek;
 }
 
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
 internal sealed class BSDFuseOperations
 {
     #region Delegates

--- a/FuseDotNet/Native/NativeMethods.cs
+++ b/FuseDotNet/Native/NativeMethods.cs
@@ -32,10 +32,15 @@ internal static class NativeMethods
     /// <param name="operationsSize"></param>
     /// <param name="userData"></param>
     /// <returns><see cref="PosixResult"/></returns>
-    [DllImport(LIB_FUSE, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    internal static extern PosixResult fuse_main_real(int argc,
+    [DllImport(LIB_FUSE, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "fuse_main_real")]
+    internal static extern PosixResult LinuxFuseMainReal(int argc,
         [In, MarshalAs(UnmanagedType.LPArray)] nint[] argv,
-        [In] FuseOperations? operations, nint operationsSize, nint userData);
+        [In] LinuxFuseOperations? operations, nint operationsSize, nint userData);
+    
+    [DllImport(LIB_FUSE, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "fuse_main_real")]
+    internal static extern PosixResult BSDFuseMainReal(int argc,
+        [In, MarshalAs(UnmanagedType.LPArray)] nint[] argv,
+        [In] BSDFuseOperations? operations, nint operationsSize, nint userData);
 
     [DllImport(LIB_C, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     internal static extern PosixResult unmount([In, MarshalAs(UnmanagedStringType)] string dir, int flags);

--- a/MirrorFs/MirrorFs.csproj
+++ b/MirrorFs/MirrorFs.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/MirrorFs/MirrorFs.csproj
+++ b/MirrorFs/MirrorFs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/TempFs/TempFs.csproj
+++ b/TempFs/TempFs.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/TempFs/TempFs.csproj
+++ b/TempFs/TempFs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
Reorganized and updated struct `FuseVfsStat` to match the current kernel implementation.
Without this PR, FUSE filesystems created using this library output garbage statistics from tools like `df`

For reference: https://man7.org/linux/man-pages/man3/statvfs.3.html